### PR TITLE
Added non-CO2 negative emission check

### DIFF
--- a/code/module-B/B.1.IAM_input_reformatting.R
+++ b/code/module-B/B.1.IAM_input_reformatting.R
@@ -58,7 +58,7 @@
   ds_sector_mapping <- readData( 'MAPPINGS', ds_sector_mapping )
   region_mapping <- readData( 'MAPPINGS', ref_region_mapping )
 
-  print( paste0( 'The IAM to be processed is: ', iam_name  ) )
+  printLog( paste0( 'The IAM to be processed is: ', iam_name  ) )
 
 # -----------------------------------------------------------------------------
 # 2. Read in the input data
@@ -71,7 +71,6 @@
   year_list <- c( 2015, 2020, 2030, 2040, 2050, 2060, 2070, 2080, 2090, 2100 )
   x_year_list <- paste0( 'X', year_list )
   native_reg_list <- sort( unique( region_mapping$region ) )  
-  #R5_regions <- c( "R5ASIA", "R5LAM", "R5MAF", "R5OECD", "R5REF" )
 
   iam_data <- data_df[ , c( 'model', 'scenario', 'region', 'variable', year_list ) ]
   iam_data <- iam_data[ iam_data$model %in% iam_name, ]
@@ -145,6 +144,14 @@
                      all.y = T )
   iam_data[ is.na( iam_data ) ] <- 0 
 
+# -----------------------------------------------------------------------------
+# 4.5 checknon-CO2 negative emissions in 2100
+  if ( any( iam_data[ iam_data$em != 'CO2', 'X2100' ] < 0 ) ) { 
+    printLog( 'There are negative non-CO2 emissions in given input file!' )
+  } else { 
+    printLog( 'All non-CO2 emissions are positive' )
+    }
+    
 # -----------------------------------------------------------------------------
 # 5. Interpolate the iam_data into all years
   all_x_years <- paste0( 'X', year_list[ 1 ] : year_list[ length( year_list ) ] )

--- a/code/module-B/B.2.IAM_reference_emission_preparation.R
+++ b/code/module-B/B.2.IAM_reference_emission_preparation.R
@@ -154,7 +154,7 @@ iam_em_ipat <- iam_em_iso_added[ iam_em_iso_added$sector %in% sector_ipat, ]
 
 # -----------------------------------------------------------------------------
 # 4.5 Convergence year value calculation for energy relatd  
-calculateCeonYear <- function( iam_em_ipat ) { 
+calculateConYear <- function( iam_em_ipat ) { 
   
   calc_baseyears <- c( 2090, 2100 )  
   iam_em_ipat_header_cols <- grep( 'X', colnames( iam_em_ipat ), value = T, invert = T  )
@@ -175,7 +175,7 @@ calculateCeonYear <- function( iam_em_ipat ) {
   return( iam_em_ipat )
 }
 
-iam_em_ipat <- calculateCeonYear( iam_em_ipat )
+iam_em_ipat <- calculateConYear( iam_em_ipat )
 
 # -----------------------------------------------------------------------------
 # 5 Write out

--- a/exe/launchpad/launch_downscaling_gridding.R
+++ b/exe/launchpad/launch_downscaling_gridding.R
@@ -56,8 +56,6 @@ input_file <- args_from_makefile[ 3 ]
 modb_out <- args_from_makefile[ 4 ]    
 modc_out <- args_from_makefile[ 5 ]
 gridding_flag <- args_from_makefile[ 6 ]
-#input_file_wo_path <- tail( unlist( strsplit( input_file, '/' ) ), n = 1 ) 
-#RUNSUFFIX <- substr( sha1( input_file_wo_path ), 1, 6 ) 
 RUNSUFFIX <- substr( sha1( runif(1) ), 1, 6 ) 
 
 # update domainmapping for current run 


### PR DESCRIPTION
After reading in emissions in script B.1.IAM_input_reformatting.R, a check for checking the existence of non-CO2 negative emissions is added. There should be no non-CO2 negative emissions, but if there are for any reason, a warning is printed and written into log. 

  